### PR TITLE
Add Filament 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php": "^8.2",
     "filafly/filament-icons": "^2.0",
     "codeat3/blade-phosphor-icons": "^2.3",
-    "filament/filament": "^4.0"
+    "filament/filament": "^4.0 || ^5.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This updates the Composer requirements to allow filament/filament ^5.0 in addition to ^4.0.

No functional changes. Existing behaviour remains unchanged.